### PR TITLE
Resolve "When DataRangeSpecDto is not null, the dateTimePropertiesNames must not be null or empty"

### DIFF
--- a/core/src/main/java/si/jernej/mexplorer/core/service/ClinicalTextService.java
+++ b/core/src/main/java/si/jernej/mexplorer/core/service/ClinicalTextService.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import si.jernej.mexplorer.core.manager.MimicEntityManager;
+import si.jernej.mexplorer.core.util.EntityUtils;
 import si.jernej.mexplorer.processorapi.v1.model.ClinicalTextConfigDto;
 import si.jernej.mexplorer.processorapi.v1.model.ClinicalTextResultDto;
 import si.jernej.mexplorer.processorapi.v1.model.DataRangeSpecDto;
@@ -50,6 +51,9 @@ public class ClinicalTextService
         {
             return Collections.emptySet();
         }
+
+        EntityUtils.assertForeignKeyPathValid(clinicalTextConfigDto.getForeignKeyPath(), mimicEntityManager.getMetamodel());
+        EntityUtils.assertDateTimeLimitSpecValidForClinicalTextExtraction(clinicalTextConfigDto, mimicEntityManager.getMetamodel());
 
         DataRangeSpecDto dataRangeSpec = clinicalTextConfigDto.getDataRangeSpec();
         String idPropertyName = clinicalTextConfigDto.getRootEntitiesSpec().getIdProperty();

--- a/core/src/main/java/si/jernej/mexplorer/core/util/EntityUtils.java
+++ b/core/src/main/java/si/jernej/mexplorer/core/util/EntityUtils.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import si.jernej.mexplorer.core.exception.ValidationCoreException;
 import si.jernej.mexplorer.core.processing.spec.PropertySpec;
 import si.jernej.mexplorer.core.processing.transform.CompositeColumnCreator;
+import si.jernej.mexplorer.processorapi.v1.model.ClinicalTextConfigDto;
 
 public final class EntityUtils
 {
@@ -412,6 +413,21 @@ public final class EntityUtils
                 }
 
             }
+        }
+    }
+
+    public static void assertDateTimeLimitSpecValidForClinicalTextExtraction(ClinicalTextConfigDto clinicalTextConfigDto, Metamodel metamodel)
+    {
+        if (clinicalTextConfigDto.getDataRangeSpec() != null && (clinicalTextConfigDto.getDateTimePropertiesNames() == null || clinicalTextConfigDto.getDateTimePropertiesNames().isEmpty()))
+        {
+            throw new ValidationCoreException("DateTime property names must be specified when data range specified.");
+        }
+
+        List<String> foreignKeyPath = clinicalTextConfigDto.getForeignKeyPath();
+
+        for (String dateTimePropertyName : clinicalTextConfigDto.getDateTimePropertiesNames())
+        {
+            assertEntityAndPropertyValid(foreignKeyPath.get(foreignKeyPath.size() - 1), dateTimePropertyName, metamodel);
         }
     }
 }


### PR DESCRIPTION
closes #99.